### PR TITLE
Fix GitHub Pages base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ VITE_FORMSPREE_ENDPOINT=https://formspree.io/f/yourFormId
 ## 📄 GitHub Pages 部署
 
 1. **设置 base 路径**（若部署到项目页而非用户根域）：
+   - Vite 默认会使用根路径 `/`；若仓库部署在 `https://<用户名>.github.io/<仓库名>/`，请在构建前设置 `VITE_BASE_PATH`，例如 PowerShell：`set VITE_BASE_PATH=/ASimpleStarGazer/`。
    - 可在 `package.json` 增加 `"homepage": "https://<用户名>.github.io/<仓库名>/"`（辅助部分工具）。
-   - 构建前设置环境变量，例如 PowerShell：`set VITE_BASE_PATH=/ASimpleStarGazer/`。
 
 2. **新增 GitHub Actions 工作流**（`.github/workflows/deploy.yml`）：
 

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,8 @@ VITE_FORMSPREE_ENDPOINT=https://formspree.io/f/yourFormId
 ## 📄 GitHub Pages 部署
 
 1. **设置 base 路径**（若部署到项目页而非用户根域）：
+   - Vite 默认会使用根路径 `/`；若仓库部署在 `https://<用户名>.github.io/<仓库名>/`，请在构建前设置 `VITE_BASE_PATH`，例如 PowerShell：`set VITE_BASE_PATH=/ASimpleStarGazer/`。
    - 可在 `package.json` 增加 `"homepage": "https://<用户名>.github.io/<仓库名>/"`（辅助部分工具）。
-   - 构建前设置环境变量，例如 PowerShell：`set VITE_BASE_PATH=/ASimpleStarGazer/`。
 
 2. **新增 GitHub Actions 工作流**（`.github/workflows/deploy.yml`）：
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,13 +6,23 @@ import react from "@vitejs/plugin-react";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const normalizeBasePath = (value: string | undefined) => {
+  if (!value || value === "/") {
+    return "/";
+  }
+
+  const trimmed = value.replace(/^\/+/g, "").replace(/\/+$/g, "");
+  return `/${trimmed}/`;
+};
+
+const basePath = normalizeBasePath(process.env.VITE_BASE_PATH);
+
 export default defineConfig({
-  // 固定 base 路径，确保在 GitHub Pages 项目页上能正常工作
-  base: "/ASimpleStarGazerWEB/",
+  // 允许通过 VITE_BASE_PATH 覆盖，默认部署到根目录
+  base: basePath,
   plugins: [react()],
   build: {
-    outDir: "docs",   // 直接输出到 docs 目录，方便 GitHub Pages 部署
-    sourcemap: true,  // 可选：方便调试
+    sourcemap: true, // 可选：方便调试
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- normalize the Vite base path and allow overriding it through the VITE_BASE_PATH environment variable so the build works for both root and project pages
- rely on the default dist output directory to align with the GitHub Pages action artifact upload path
- document the new base-path behaviour in both READMEs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c0afa85883289895f9aabee2d9ee